### PR TITLE
Implementation of branch command

### DIFF
--- a/.full-build/anthology
+++ b/.full-build/anthology
@@ -5,7 +5,6 @@ anthology:
   test: nunit
   vcs: git
   mainrepository:
-    branch: master
     uri: http://www.google.com/
   repositories:
     - repo: src

--- a/src/FullBuild/Anthology.yaml
+++ b/src/FullBuild/Anthology.yaml
@@ -5,7 +5,6 @@
     test: nunit
     vcs: git
     mainrepository:
-        branch: master
         uri: http://www.google.com
     repositories:
         - repo: id1

--- a/src/FullBuild/AnthologySerializer.fs
+++ b/src/FullBuild/AnthologySerializer.fs
@@ -50,9 +50,6 @@ let Serialize (antho : Anthology) =
 
     let cmainrepo = config.anthology.mainrepository
     cmainrepo.uri <- Uri (antho.MasterRepository.Url.toString)
-    match antho.MasterRepository.Branch with
-    | None -> cmainrepo.branch <- null
-    | Some x -> cmainrepo.branch <- x.toString
 
     config.anthology.projects.Clear()
     for project in antho.Projects do
@@ -97,10 +94,8 @@ let Deserialize (content) =
         | x :: tail -> (RepositoryUrl.from (x.nuget)) :: convertToNuGets tail
 
     let convertToRepository (item : AnthologyConfig.anthology_Type.mainrepository_Type) : Repository =  
-        let maybeBranch = if String.IsNullOrEmpty(item.branch) then None
-                          else item.branch |> BranchId.from |> Some
         { Url = RepositoryUrl.from (item.uri)
-          Branch = maybeBranch 
+          Branch = None 
           Name = RepositoryId.from Env.MASTER_REPO }
 
     let rec convertToBuildableRepositories (items : AnthologyConfig.anthology_Type.repositories_Item_Type list) =

--- a/src/FullBuild/CommandLine.fs
+++ b/src/FullBuild/CommandLine.fs
@@ -31,9 +31,6 @@ type InitWorkspace =
 type CheckoutWorkspace = 
     { Version : string }
 
-type BranchWorkspace = 
-    { Branch : string }
-
 type CloneRepositories = 
     { Filters : RepositoryId set 
       Shallow : bool
@@ -65,6 +62,9 @@ type PublishApplications =
 
 type CheckoutVersion =
     { Version : BookmarkVersion }
+
+type BranchWorkspace = 
+    { Branch : BookmarkVersion option }
 
 type AddApplication =
     { Name : ApplicationId
@@ -126,7 +126,7 @@ type Command =
     | ConvertRepositories of ConvertRepositories
     | PushWorkspace of PushWorkspace
     | CheckoutWorkspace of CheckoutVersion
-    | BranchWorkspace of CheckoutVersion
+    | BranchWorkspace of BranchWorkspace
     | PullWorkspace of PullWorkspace
     | Exec of Exec
     | CleanWorkspace

--- a/src/FullBuild/CommandLine.fs
+++ b/src/FullBuild/CommandLine.fs
@@ -31,6 +31,9 @@ type InitWorkspace =
 type CheckoutWorkspace = 
     { Version : string }
 
+type BranchWorkspace = 
+    { Branch : string }
+
 type CloneRepositories = 
     { Filters : RepositoryId set 
       Shallow : bool
@@ -123,6 +126,7 @@ type Command =
     | ConvertRepositories of ConvertRepositories
     | PushWorkspace of PushWorkspace
     | CheckoutWorkspace of CheckoutVersion
+    | BranchWorkspace of CheckoutVersion
     | PullWorkspace of PullWorkspace
     | Exec of Exec
     | CleanWorkspace

--- a/src/FullBuild/CommandLineParsing.fs
+++ b/src/FullBuild/CommandLineParsing.fs
@@ -124,6 +124,11 @@ let commandCheckout (args : string list) =
     | [MatchBookmarkVersion version] -> Command.CheckoutWorkspace {Version = version}
     | _ -> Command.Error
 
+let commandBranch (args : string list) =
+    match args with
+    | [MatchBookmarkVersion version] -> Command.CheckoutWorkspace {Version = version}
+    | _ -> Command.Error
+
 let commandPush (args : string list) =
     match args with
     | [buildNumber] -> Command.PushWorkspace { BuildNumber = buildNumber }
@@ -280,6 +285,7 @@ let ParseCommandLine (args : string list) : Command =
     | Token Token.Build :: cmdArgs -> cmdArgs |> commandBuild "Release" false false None
     | Token Token.Rebuild :: cmdArgs -> cmdArgs |> commandBuild "Release" true false None
     | Token Token.Checkout :: cmdArgs -> cmdArgs |> commandCheckout
+    | Token Token.Branch :: cmdArgs -> cmdArgs |> commandBranch
     | Token Token.Push :: cmdArgs -> cmdArgs |> commandPush
     | Token Token.Pull :: cmdArgs -> cmdArgs |> commandPull true true false
     | Token Token.Clean :: cmdArgs -> cmdArgs |> commandClean
@@ -345,6 +351,7 @@ let UsageContent() =
         "  init <master-repository> <local-path> : initialize a new workspace in given path"
         "  clone [--shallow] [--all] <repo-wildcard>+ : clone repositories using provided wildcards"
         "  checkout <version> : checkout workspace to version"
+        "  branch <branch> : checkout workspace to branch"
         "  install : install packages"
         "  view [--src] <view-name> <view-wildcard>+ : add repositories to view"
         "  open [--src] <viewName> : open view with your favorite ide"

--- a/src/FullBuild/CommandLineParsing.fs
+++ b/src/FullBuild/CommandLineParsing.fs
@@ -126,7 +126,8 @@ let commandCheckout (args : string list) =
 
 let commandBranch (args : string list) =
     match args with
-    | [MatchBookmarkVersion version] -> Command.BranchWorkspace {Version = version}
+    | [MatchBookmarkVersion version] -> Command.BranchWorkspace {Branch = Some version}
+    | [] -> Command.BranchWorkspace {Branch = None}
     | _ -> Command.Error
 
 let commandPush (args : string list) =
@@ -351,7 +352,7 @@ let UsageContent() =
         "  init <master-repository> <local-path> : initialize a new workspace in given path"
         "  clone [--shallow] [--all] <repo-wildcard>+ : clone repositories using provided wildcards"
         "  checkout <version> : checkout workspace to version"
-        "  branch <branch> : checkout workspace to branch"
+        "  branch [<branch>] : checkout workspace to branch"
         "  install : install packages"
         "  view [--src] <view-name> <view-wildcard>+ : add repositories to view"
         "  open [--src] <viewName> : open view with your favorite ide"

--- a/src/FullBuild/CommandLineParsing.fs
+++ b/src/FullBuild/CommandLineParsing.fs
@@ -126,7 +126,7 @@ let commandCheckout (args : string list) =
 
 let commandBranch (args : string list) =
     match args with
-    | [MatchBookmarkVersion version] -> Command.CheckoutWorkspace {Version = version}
+    | [MatchBookmarkVersion version] -> Command.BranchWorkspace {Version = version}
     | _ -> Command.Error
 
 let commandPush (args : string list) =

--- a/src/FullBuild/CommandLineToken.fs
+++ b/src/FullBuild/CommandLineToken.fs
@@ -28,7 +28,7 @@ type TokenOption =
     | Version
     | Sticky
     | Rebase
-    | Optimize
+    | Reset
     | Unknown
 
 let (|TokenOption|) (token : string) =
@@ -45,6 +45,7 @@ let (|TokenOption|) (token : string) =
     | "--version" -> TokenOption.Version
     | "--sticky" -> TokenOption.Sticky
     | "--rebase" -> TokenOption.Rebase
+    | "--reset" -> TokenOption.Reset
     | _ -> Unknown
 
 

--- a/src/FullBuild/CommandLineToken.fs
+++ b/src/FullBuild/CommandLineToken.fs
@@ -69,6 +69,7 @@ type Token =
     | Publish
     | Pull
     | Checkout
+    | Branch
     | Exec
     | Test
     | Alter
@@ -115,6 +116,7 @@ let (|Token|) (token : string) =
     | "publish" -> Publish
     | "pull" -> Pull
     | "checkout" -> Checkout
+    | "branch" -> Branch
     | "exec" -> Exec
     | "clean" -> Clean
     | "test" -> Test

--- a/src/FullBuild/Program.fs
+++ b/src/FullBuild/Program.fs
@@ -29,6 +29,7 @@ let tryMain argv =
     | ConvertRepositories convInfo -> Workspace.Convert convInfo.Filters
     | PushWorkspace buildInfo -> Workspace.Push buildInfo.BuildNumber
     | CheckoutWorkspace version -> Workspace.Checkout version.Version
+    | BranchWorkspace branch -> Workspace.Branch branch.Version
     | PullWorkspace pullInfo -> Workspace.Pull pullInfo.Src pullInfo.Bin pullInfo.Rebase
     | Exec cmd -> Workspace.Exec cmd.Command cmd.All
     | CleanWorkspace -> Workspace.Clean ()

--- a/src/FullBuild/Program.fs
+++ b/src/FullBuild/Program.fs
@@ -29,7 +29,7 @@ let tryMain argv =
     | ConvertRepositories convInfo -> Workspace.Convert convInfo.Filters
     | PushWorkspace buildInfo -> Workspace.Push buildInfo.BuildNumber
     | CheckoutWorkspace version -> Workspace.Checkout version.Version
-    | BranchWorkspace branch -> Workspace.Branch branch.Version
+    | BranchWorkspace branch -> Workspace.Branch branch.Branch
     | PullWorkspace pullInfo -> Workspace.Pull pullInfo.Src pullInfo.Bin pullInfo.Rebase
     | Exec cmd -> Workspace.Exec cmd.Command cmd.All
     | CleanWorkspace -> Workspace.Clean ()

--- a/src/FullBuild/Workspace.fs
+++ b/src/FullBuild/Workspace.fs
@@ -121,7 +121,7 @@ let Checkout (version : BookmarkVersion) =
     let antho = Configuration.LoadAnthology ()
     let wsDir = Env.GetFolder Env.Workspace
     let mainRepo = antho.MasterRepository
-    Vcs.VcsCheckout wsDir antho.Vcs mainRepo (Some version)
+    Vcs.VcsCheckout wsDir antho.Vcs mainRepo (Some version) false
 
     // checkout each repository now
     let antho = Configuration.LoadAnthology ()
@@ -131,11 +131,27 @@ let Checkout (version : BookmarkVersion) =
         DisplayHighlight repo.Name.toString
         let repoVersion = baseline.Bookmarks |> Seq.tryFind (fun x -> x.Repository = repo.Name)
         match repoVersion with
-        | Some x -> Vcs.VcsCheckout wsDir antho.Vcs repo (Some x.Version)
-        | None -> Vcs.VcsCheckout wsDir antho.Vcs repo None
+        | Some x -> Vcs.VcsCheckout wsDir antho.Vcs repo (Some x.Version) false
+        | None -> Vcs.VcsCheckout wsDir antho.Vcs repo None false
 
     // update binaries with observable baseline
     BuildArtifacts.PullReferenceBinaries version.toString
+
+let Branch (branch : BookmarkVersion) =
+    // checkout repositories
+    DisplayHighlight ".full-build"
+    let antho = Configuration.LoadAnthology ()
+    let wsDir = Env.GetFolder Env.Workspace
+    let mainRepo = antho.MasterRepository
+    Vcs.VcsCheckout wsDir antho.Vcs mainRepo (Some branch) false
+
+    // checkout each repository now
+    let antho = Configuration.LoadAnthology ()
+    let clonedRepos = antho.Repositories |> ClonedRepositories wsDir
+    for repo in clonedRepos do
+        DisplayHighlight repo.Name.toString
+        Vcs.VcsCheckout wsDir antho.Vcs repo (Some branch) true
+
 
 let Pull (src : bool) (bin : bool) (rebase : bool) =
     let antho = Configuration.LoadAnthology ()

--- a/src/FullBuild/Workspace.fs
+++ b/src/FullBuild/Workspace.fs
@@ -137,20 +137,25 @@ let Checkout (version : BookmarkVersion) =
     // update binaries with observable baseline
     BuildArtifacts.PullReferenceBinaries version.toString
 
-let Branch (branch : BookmarkVersion) =
+let Branch (branch : BookmarkVersion option) =
     // checkout repositories
     DisplayHighlight ".full-build"
     let antho = Configuration.LoadAnthology ()
     let wsDir = Env.GetFolder Env.Workspace
     let mainRepo = antho.MasterRepository
-    Vcs.VcsCheckout wsDir antho.Vcs mainRepo (Some branch) false
+    Vcs.VcsCheckout wsDir antho.Vcs mainRepo branch false
 
     // checkout each repository now
     let antho = Configuration.LoadAnthology ()
     let clonedRepos = antho.Repositories |> ClonedRepositories wsDir
     for repo in clonedRepos do
         DisplayHighlight repo.Name.toString
-        Vcs.VcsCheckout wsDir antho.Vcs repo (Some branch) true
+        let repoVer = match branch with
+                      | None -> match repo.Branch with
+                                | None -> None
+                                | Some x -> Some (BookmarkVersion.from x.toString)
+                      | Some x -> Some x
+        Vcs.VcsCheckout wsDir antho.Vcs repo repoVer true
 
 
 let Pull (src : bool) (bin : bool) (rebase : bool) =


### PR DESCRIPTION
This command allows to switch all repositories to given view.
Only branch on full-build repository is required.
Branch is not mandatory on other repository - no switch will happen.
This is useful to have branch for cross-repository work.

The command also support branch reset. Just pass no branch and this will restore default branch on all repositories.