### PR TITLE
implement auto repository filter for view

### DIFF
--- a/src/FullBuild/View.fs
+++ b/src/FullBuild/View.fs
@@ -31,10 +31,15 @@ let filterClonedRepositories (wsDir : System.IO.DirectoryInfo) (repo : Repositor
     let exists = repoDir.Exists
     exists
 
+
+let private adaptViewFilter (filter : string) =
+    if filter.Contains("/") || filter.Contains("*") then filter
+    else filter + "/*"
+
 let findViewProjects (view : View) =
     // load back filter & generate view accordingly
     let wsDir = Env.GetFolder Folder.Workspace
-    let repoFilters = view.Filters |> Set
+    let repoFilters = view.Filters |> Set.map adaptViewFilter
 
     let antho = Configuration.LoadAnthology ()
 


### PR DESCRIPTION
view command use a filter matching repository/project.

this patch detect if only repository is provided (/ and * not found in filter) and automatically happens /* to select all projects of repository.