### PR TITLE
fix --all command for graph command (previous was --view instead --all)

### DIFF
--- a/src/FullBuild/CLI/CommandLine.fs
+++ b/src/FullBuild/CLI/CommandLine.fs
@@ -277,7 +277,7 @@ let rec private commandClone (shallow : bool) (all : bool) (mt : bool) (args : s
 
 let rec private commandGraph (all : bool) (args : string list) =
     match args with
-    | TokenOption TokenOption.View
+    | TokenOption TokenOption.All
       :: tail -> tail |> commandGraph true
     | [ViewId name] -> Command.GraphView { Name = name ; All = all }
     | _ -> Command.Error MainCommand.GraphView


### PR DESCRIPTION
The command help suggest --all option to see full graph (including test projects) but the --view option was used in the command parser.